### PR TITLE
Feature clear search on Focus

### DIFF
--- a/client/templates/search.html
+++ b/client/templates/search.html
@@ -15,9 +15,9 @@
     </form>
     <script>
 	    $(document).ready(function () {
-	        $('#search').focus(function() {
+	        $('#search').click(function() {
 				if($(this).val() != '')
-				$(this).val('');
+				$(this).select();
 			});
 	    });
     </script>

--- a/client/templates/search.html
+++ b/client/templates/search.html
@@ -13,4 +13,12 @@
             {{/if}}
         </div>
     </form>
+    <script>
+	    $(document).ready(function () {
+	        $('#search').focus(function() {
+				if($(this).val() != '')
+				$(this).val('');
+			});
+	    });
+    </script>
 </template>

--- a/client/templates/search.html
+++ b/client/templates/search.html
@@ -15,9 +15,12 @@
     </form>
     <script>
 	    $(document).ready(function () {
-	        $('#search').click(function() {
-				if($(this).val() != '')
-				$(this).select();
+			$('#search').focus(function () {
+				$('#search').setSelectionRange(0, 9999);
+			    $('#search').select().mouseup(function (e) {
+			        e.preventDefault();
+			        $(this).unbind("mouseup");
+			    });
 			});
 	    });
     </script>


### PR DESCRIPTION
I was adding lots of movies with my girlfriend last night on my iPhone (which this app you created is faster than the mobile couchpotato!) and I kept needing to delete the last search which was annoying.

I added some javascript to clear the search on field focus.

I polled some other people on best practices:
1. Clear field on focus
2. Add a clear field X option
3. Leave as is

All thought a focus clear was best, some wanted the previous search to be semi saved in a div below to be clicked and populate the field incase they just wanted to correct the result but that seemed like a lot of needless work.

I also considered checking the results:
1. If search replied with "no results" don't clear field, let user edit it.
2. If search, but not requested yet don't clear field, let user edit it.
3. else clear results