### PR TITLE
initial docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM meteorhacks/meteord:onbuild

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Installation is straightforward: please update to Meteor 1.2.1, clone the repo, 
 
 On first run navigate to `http://localhost:3000/admin` and create an admin account with an email address and password. **If this isn't done someone else can create the admin account to your application.** This account is only used for logging in, email integration isn't enabled. Once logged in, you can configure your settings and get things going.
 
+## Docker
+To use the bundled docker-compose simply run it with
+
+```docker-compose up```
+
+(add -d to run it as a daemon)
+
 ## FAQ
 Please visit the projects [GitHub page](http://plexrequests.8bits.ca/) for [FAQ page](http://plexrequests.8bits.ca/faq)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# docker-compose.yml
+
+dashboard:
+  image: jkaberg/docker-plexrequests-meteor
+  ports:
+   - "8989:80"
+  links:
+   - mongo
+  environment:
+   - MONGO_URL=mongodb://mongo:27017/plexrequests
+
+mongo:
+  image: mongo:latest


### PR DESCRIPTION
This is a fully working docker-compose container

This is the real docker way, where the mongo db is seperated from the main app

To have the docker container built when you push an commit simply create an automated build @ hub.docker.com and point it to this repo (it's an 5 min initial setup, then you can forget about it again). Just remember to change line 4 in docker-compose.yaml