### PR TITLE
added env variable for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ dashboard:
    - mongo
   environment:
    - MONGO_URL=mongodb://mongo:27017/plexrequests
+   - ROOT_URL=http://localhost/
 
 mongo:
   image: mongo:latest


### PR DESCRIPTION
I was having trouble building the Docker image using the current compose file. Error was something like (I didn't save the full exception):

`Error: Must pass options.rootUrl or set ROOT_URL in the server environment`

I was able to resolve by passing the ROOT_URL environment variable from within the compose file. Everything worked after that. Not familiar enough with Meteor to know if this could cause other issues.