### PR TITLE
Added option to use a Pushbullet Channel Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 * [CouchPotato](https://couchpota.to/) integration for automatic downloads of Movies
 * [SickRage](https://github.com/SickRage/SickRage) and [Sonarr](https://sonarr.tv/) integrationed for automatic TV Series downloads
 * [Pushbullet](https://www.pushbullet.com/), [Pushover](https://pushover.net/) and [Slack](https://slack.com/) notifications to keep up to date with requests
+    * You can now push notifications to a custom channel to easily notify others whenever new content is requested and added. Users only need to
+        subscribe to the channel to start recieving notifications. Visit the [Channel Creation Page](https://www.pushbullet.com/my-channel) to learn more about how to create and distribute your own channel.
 
 ## Installation
 Installation is straightforward: please update to Meteor 1.2.1, clone the repo, `cd` into the directory, and run `meteor`. For Windows users check out this [blog post](http://8bits.ca/posts/2015/installing-plex-requests-on-windows/) for installation instructions using Git!

--- a/client/templates/admin/admin.html
+++ b/client/templates/admin/admin.html
@@ -197,10 +197,9 @@
 						{{> afQuickField name='pushbulletAPI' size="40"}}
 						<p class="text-muted">Enter your API from Pushbullet. It can be found in Pushbullet Settings -> Access Token.</p>
 						<br>
-            {{> afQuickField name='pushbulletChannel' size="40"}}
-						<p class="text-muted">Enter your API from Pushbullet. It can be found in Pushbullet Settings -> Access Token.</p>
-						<br>
-                                        
+						{{> afQuickField name='pushbulletChannel' size="40"}}
+                                              	<p class="text-muted"> Push Notifications to a channel. Must be the owner of the channel, click <a href="https://www.pushbullet.com/my-channel"> here </a> to create a new channel. </p>
+
 						<p><button class="btn btn-secondary-outline" id="pushbulletTest">Test Pushbullet</button></p>
 						<p class="text-muted">Test your Pushbullet settings. Remember to save your settings first!</p>
 						<br>

--- a/client/templates/admin/admin.html
+++ b/client/templates/admin/admin.html
@@ -197,6 +197,10 @@
 						{{> afQuickField name='pushbulletAPI' size="40"}}
 						<p class="text-muted">Enter your API from Pushbullet. It can be found in Pushbullet Settings -> Access Token.</p>
 						<br>
+            {{> afQuickField name='pushbulletChannel' size="40"}}
+						<p class="text-muted">Enter your API from Pushbullet. It can be found in Pushbullet Settings -> Access Token.</p>
+						<br>
+                                        
 						<p><button class="btn btn-secondary-outline" id="pushbulletTest">Test Pushbullet</button></p>
 						<p class="text-muted">Test your Pushbullet settings. Remember to save your settings first!</p>
 						<br>

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -321,6 +321,12 @@ Settings.attachSchema(new SimpleSchema ({
     defaultValue: "abcd1234",
     optional: true
   },
+  pushbulletChannel: {
+    type: String,
+    label: "Pushbullet Channel Tag",
+    defaultValue: "test-channel",
+    optional: true
+  },
   pushbulletENABLED: {
     type: Boolean,
     label: "Enable Pushbullet notifications",

--- a/server/methods/notifications/pushbulletNotification.js
+++ b/server/methods/notifications/pushbulletNotification.js
@@ -1,6 +1,7 @@
 Meteor.methods({
   "sendPushbulletNotification": function (settings, title, body) {
     var access_token = settings.pushbulletAPI;
+    var channel_tag = settings.pushbulletChannel;
     var pushbullet_url = 'https://api.pushbullet.com/v2/pushes';
 
     try {
@@ -13,7 +14,8 @@ Meteor.methods({
           params: {
             type: 'note',
             title: title,
-            body: body
+            body: body,
+            channel: channel_tag
           },
           timeout: 4000
         }


### PR DESCRIPTION
I wanted to be able to have Pushbullet notifications be sent to multiple users so that they too could get updates on when content gets requested/approved and ultimately added to PleX (by utilizing the Pushbullet settings in both Sonarr and CouchPotato you can easily setup a solid distributed notification system). So I dug in and made a few changes to add this functionality and it seems to work great.

As of now you can only send to one channel but I will adding the ability to send to multiple channels soon.  I also plan on rounding it out by adding the ability to limit sending notifications to individual devices based on registered device ID's.