### PR TITLE
Don't use plexUsername without initialization

### DIFF
--- a/server/methods/authentication/plexAuthentication.js
+++ b/server/methods/authentication/plexAuthentication.js
@@ -44,13 +44,13 @@ Meteor.methods({
 
     },
 
-    'checkPlexUser': function (plexLogin, plexPassword) {
-        check(plexLogin, String)
+    'checkPlexUser': function (plexUsername, plexPassword) {
+        check(plexUsername, String)
         check(plexPassword, String)
 
         if (Settings.find({}).fetch()[0].plexAuthenticationPASSWORDS) {
             // If passwords are required check full login
-            var userInfo = Meteor.call('plexLogin', plexLogin, plexPassword)
+            var userInfo = Meteor.call('plexLogin', plexUsername, plexPassword)
             var plexUsername = userInfo.username
         }
 


### PR DESCRIPTION
`plexLogin` -> `plexUsername` similar to what it was previously

Fixes #514, #515, #527 